### PR TITLE
fix: correct Renovate preset configuration for best practices

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,11 +18,13 @@ All configuration options used in this preset are stable, core features with no 
 - `:semanticCommits` - Enables conventional commit message format
 
 **Core Settings:**
+- `dependencyDashboard: true` - Enables dependency dashboard to monitor pending updates
 - `automergeType: "branch"` - Silent automerge (PR only created if tests fail)
 - `platformAutomerge: true` - Uses GitHub's native auto-merge feature
 - `branchConcurrentLimit: 3` - Maximum 3 concurrent update branches
 - `minimumReleaseAge: "3 days"` - Global stabilization period for all automerged updates
-- `prCreation: "not-pending"` - Create PRs immediately, don't wait for status
+- `internalChecksFilter: "strict"` - Strictly enforce minimumReleaseAge before creating branches
+- `prCreation: "status-success"` - Only create PRs after tests pass (for failed branch automerges)
 - `rebaseWhen: "behind-base-branch"` - Keep branches up to date
 - `lockFileMaintenance` - Monday 4am automated lock file updates for transitive dependencies
 - `vulnerabilityAlerts` - Enabled with `security` label, manual review required
@@ -153,20 +155,24 @@ Must use prefix: `"custom.regex"`
 
 **Configuration:**
 ```json
+"dependencyDashboard": true,
 "automergeType": "branch",
 "platformAutomerge": true,
 "branchConcurrentLimit": 3,
-"minimumReleaseAge": "3 days"
+"prCreation": "status-success",
+"minimumReleaseAge": "3 days",
+"internalChecksFilter": "strict"
 ```
 
 **Behavior:**
 1. Renovate creates a branch for updates
-2. **Waits 3 days after release** (stabilization period)
+2. **Waits 3 days after release** (stabilization period, strictly enforced via `internalChecksFilter`)
 3. CI runs on the branch after waiting period
 4. **If tests pass:** Changes pushed directly to base branch (silent merge)
-5. **If tests fail:** PR created for manual review
+5. **If tests fail:** PR created for manual review (only after tests complete via `prCreation: "status-success"`)
 6. No notifications for successful automerges
 7. Maximum 3 concurrent update branches to avoid overwhelming CI
+8. **Dependency Dashboard** shows pending updates waiting for stabilization period
 
 **Global Stabilization Period:**
 - `minimumReleaseAge: "3 days"` applies to **all automerged updates** without exception
@@ -296,11 +302,18 @@ Format: `camelCase`
 - Lock file maintenance enabled (transitive deps)
 - Digest pinning for GitHub Actions (via `config:best-practices`)
 - Gitleaks in pre-commit hooks
+- `internalChecksFilter: "strict"` ensures stabilization period is enforced
 
 ✅ **Aggressive Automerge, Safe Boundaries**
 - Non-major updates auto-merge (semantic versioning trust)
 - Major updates require review (breaking changes possible)
 - CI must pass before any automerge
+- Dependency Dashboard provides visibility into pending updates
+
+✅ **Correct packageRules Ordering**
+- Rules ordered from least to most important (per Renovate docs)
+- General rules first, specific overrides last
+- Most important rule (`major` requiring review) comes last
 
 ## Documentation References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,18 +48,21 @@ The preset is **not a Python codebase** - it's a Renovate configuration file pub
 - Includes custom regex support (`custom.regex`) for flexibility
 
 **Poetry → uv Migration:**
-- Poetry manager: Marked DEPRECATED with clear comment in `default.json:37-45`
+- Poetry manager: Marked DEPRECATED with clear comment in `default.json:31-39`
 - Remove Poetry from `enabledManagers` after migration complete
 - uv support: Via `pep621` manager (auto-detected by `uv.lock` presence)
 
 **Automerge Strategy:**
+- `dependencyDashboard: true` - Monitor pending updates waiting for stabilization
 - `automergeType: "branch"` - Silent automerge (PR only created if tests fail)
 - `platformAutomerge: true` - Uses GitHub native auto-merge
 - `branchConcurrentLimit: 3` - Maximum 3 concurrent update branches
+- `prCreation: "status-success"` - Only create PRs after tests complete (for failed branch automerges)
 - `minimumReleaseAge: "3 days"` - **Global 3-day stabilization** for all automerged updates (no exceptions)
   - Applies to: pre-commit, github-actions, non-major updates (minor/patch/pin/digest)
   - Rationale: Community has time to find issues before automerge
   - Can be overridden per packageRule if needed (e.g., internal SBB packages)
+- `internalChecksFilter: "strict"` - Strictly enforce stabilization period
 - Pre-commit: `ignoreTests: true` - automerges even if CI fails
 - GitHub Actions: Requires CI to pass before automerge
 - Major updates: Require manual review (`automerge: false`)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Renovate bot preset configuration for Python projects at SBB (Schweizerische Bun
 ### Automerge Strategy
 - 🔀 **Branch-based automerge** - Silent merges when tests pass
 - 🤖 **Platform automerge** - Uses GitHub's native auto-merge feature
-- ⏱️ **3-day stabilization** - All updates wait 3 days after release before automerge
+- ⏱️ **3-day stabilization** - All updates wait 3 days after release before automerge (strictly enforced)
 - 🔢 **Concurrent limit** - Maximum 3 update branches to avoid overwhelming CI
+- 📊 **Dependency Dashboard** - Monitor pending updates waiting for stabilization
 - 📦 **Lock file maintenance** - Monday 4am transitive dependency updates
 - 🔒 **Safe boundaries** - Manual review required for major updates and security alerts
 - 🔐 **Security alerts** - Manual review with `security` label

--- a/default.json
+++ b/default.json
@@ -12,12 +12,14 @@
     "github-actions",
     "custom.regex"
   ],
+  "dependencyDashboard": true,
   "automergeType": "branch",
   "platformAutomerge": true,
   "branchConcurrentLimit": 3,
-  "prCreation": "not-pending",
+  "prCreation": "status-success",
   "rebaseWhen": "behind-base-branch",
   "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
@@ -26,21 +28,6 @@
     ]
   },
   "packageRules": [
-    {
-      "description": "pre-commit - Automerge all updates",
-      "matchManagers": [
-        "pre-commit"
-      ],
-      "automerge": true,
-      "ignoreTests": true
-    },
-    {
-      "description": "Automerge GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "automerge": true
-    },
     {
       "description": "DEPRECATED: Poetry support - Remove after migration to uv is complete",
       "matchManagers": [
@@ -51,7 +38,7 @@
       ]
     },
     {
-      "description": "Automerge non-major updates",
+      "description": "Automerge non-major updates (minor, patch, pin, digest)",
       "matchUpdateTypes": [
         "minor",
         "patch",
@@ -61,7 +48,22 @@
       "automerge": true
     },
     {
-      "description": "Major updates require manual review",
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "pre-commit hooks - Automerge even if tests fail (low-risk tooling updates)",
+      "matchManagers": [
+        "pre-commit"
+      ],
+      "automerge": true,
+      "ignoreTests": true
+    },
+    {
+      "description": "Major updates require manual review (potential breaking changes)",
       "matchUpdateTypes": [
         "major"
       ],


### PR DESCRIPTION
## Summary

- Fix `prCreation` from `"not-pending"` to `"status-success"` to properly support branch automerge (PRs only created after tests fail)
- Add `internalChecksFilter: "strict"` to enforce `minimumReleaseAge` stabilization period
- Add `dependencyDashboard: true` to monitor pending updates waiting for stabilization
- Reorder `packageRules` from least to most important (per Renovate docs)

## Background

The original config had a thinking error: `prCreation: "not-pending"` creates PRs even before tests complete, which defeats the "silent merge" purpose of branch automerge. The correct setting is `"status-success"` which only creates PRs when tests fail.

## Test plan

- [x] Validate JSON syntax with `jq empty default.json`
- [x] Verify pre-commit hooks pass
- [x] Test in downstream repository with Renovate bot