### PR TITLE
feat: track python-sbb-polarion git tag via custom regex manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,5 +12,18 @@
     "pre-commit",
     "github-actions",
     "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track python-sbb-polarion pinned by git tag in [tool.uv.sources] (the pep621/uv manager does not bump git-source tags)",
+      "managerFilePatterns": [
+        "/(^|/)pyproject\\.toml$/"
+      ],
+      "matchStrings": [
+        "python-sbb-polarion\\s*=\\s*\\{[^}]*\\bgit\\s*=\\s*\"https://github\\.com/(?<depName>SchweizerischeBundesbahnen/python-sbb-polarion)\"[^}]*\\btag\\s*=\\s*\"(?<currentValue>v?[0-9][^\"]*)\""
+      ],
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }


### PR DESCRIPTION
## Problem

`python-sbb-polarion` (PSP) is pinned by **git tag** in `[tool.uv.sources]` of every `.st` repo:

```toml
[tool.uv.sources]
python-sbb-polarion = { git = "https://github.com/SchweizerischeBundesbahnen/python-sbb-polarion", tag = "v3.0.0" }
```

Renovate's `pep621`/uv manager **does not bump the `tag` of a git source**, so PSP was never tracked — it appears nowhere in the Dependency Dashboard and got no update branch. PSP **v3.1.0** (released 2026-06-12) therefore stayed invisible, while plain PyPI deps in the same `[project].dependencies` (`ruff`, `pypdf`) update normally — proving Renovate runs fine; only the git-tag dep falls through.

`"custom.regex"` was already listed in `enabledManagers`, but **no `customManagers` rules were defined**, so it did nothing.

## Fix

Add a `customManagers` regex that matches the pinned tag in `pyproject.toml` and resolves versions from the `github-releases` datasource of `SchweizerischeBundesbahnen/python-sbb-polarion`. Validated with `renovate-config-validator` ("Config validated successfully").

## Effect

Every repo consuming this preset starts getting PSP update PRs (v3.0.0 → v3.1.0 and onward).

## Caveats / follow-up

- **`minimumReleaseAge: "3 days"`** (base preset) still applies — the PR appears once a release is ≥3 days old.
- **uv.lock is not regenerated by a custom manager.** The bump updates the `tag` in `pyproject.toml` but not the `?tag=...#<commit>` pin in `uv.lock`; with `uv sync --frozen` in CI, that PR's checks may fail until the lock is re-resolved (`uv lock`). `lockFileMaintenance` (Mondays) reconciles transitively, but a clean tag-bump merge needs the consuming repo to run `uv lock` (e.g., a post-upgrade/CI step). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
