### PR TITLE
fix: remove redundant python-sbb-polarion custom manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,18 +12,5 @@
     "pre-commit",
     "github-actions",
     "custom.regex"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track python-sbb-polarion pinned by git tag in [tool.uv.sources] (the pep621/uv manager does not bump git-source tags)",
-      "managerFilePatterns": [
-        "/(^|/)pyproject\\.toml$/"
-      ],
-      "matchStrings": [
-        "python-sbb-polarion\\s*=\\s*\\{[^}]*\\bgit\\s*=\\s*\"https://github\\.com/(?<depName>SchweizerischeBundesbahnen/python-sbb-polarion)\"[^}]*\\btag\\s*=\\s*\"(?<currentValue>v?[0-9][^\"]*)\""
-      ],
-      "datasourceTemplate": "github-releases"
-    }
   ]
 }


### PR DESCRIPTION
Closes #14.

## Problem

The `custom.regex` manager added in #13 tracks `python-sbb-polarion` pinned by git tag in `pyproject.toml` `[tool.uv.sources]`, on the premise that the native `pep621` manager does not bump git-source tags.

That premise no longer holds. Current Renovate (observed on 43.x) bumps the `git = { …, tag = "vX" }` source natively via `pep621`. Both managers now extract the same dependency, producing **two** update branches and **two** Dependency Dashboard rows for a single bump in every consuming repo.

Evidence from a downstream run (`v3.1.2` → `v3.2.0`):

| Manager | depName | datasource | branch |
|---|---|---|---|
| `pep621` (native, `tool.uv.sources`) | `python-sbb-polarion` | `github-tags` | `renovate/python-sbb-polarion-3.x` |
| `custom.regex` (this preset) | `SchweizerischeBundesbahnen/python-sbb-polarion` | `github-releases` | `renovate/schweizerischebundesbahnen-python-sbb-polarion-3.x` |

Renovate itself flags the overlap (`Found sourceUrl with multiple branches that should probably be combined into a group`).

## Change

- Remove the redundant `custom.regex` manager for `python-sbb-polarion`; let the native `pep621` manager own the git-source tag bump.
- Keep `custom.regex` in `enabledManagers` — downstream repos define their own custom managers (e.g. system-test version trackers) that depend on it.

Effectively reverts the manager from #13 now that the native bump works.

## Validation

- `renovate-config-validator` (Renovate 43.x) passes on `default.json`.
- pre-commit hooks pass.

## Note for reviewers

Please confirm the `pep621` git-tag bump is reliable across the repos that consume this preset before merging (it was observed working for `tool.uv.sources` on 43.x).