### PR TITLE
refactor: drop internal-SBB rule now inherited from base preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,18 +12,5 @@
     "pre-commit",
     "github-actions",
     "custom.regex"
-  ],
-  "packageRules": [
-    {
-      "description": "Internal SBB packages and container images - skip the minimum-release-age stability wait (automerge left to the base preset: minor/patch auto, major manual; merges gated by system-tests)",
-      "matchPackagePatterns": [
-        "^ch\\.sbb\\.",
-        "^SchweizerischeBundesbahnen/ch\\.sbb\\.",
-        "^python-sbb-polarion$",
-        "^sbb\\.jfrog\\.io/polarion-docker/polarion/polarion$",
-        "^ghcr\\.io/schweizerischebundesbahnen/.+-service$"
-      ],
-      "minimumReleaseAge": "0 days"
-    }
   ]
 }


### PR DESCRIPTION
Removes this preset's `Internal SBB packages and container images` rule, which has been consolidated into the base preset (`casc-renovate-preset-polarion`).

This preset extends the base, so the exemption still applies via inheritance — **no behavioural change**.

Depends on the base-preset PR (`casc-renovate-preset-polarion#2`); **merge that first** so the exemption is never momentarily lost.

Validated with `renovate-config-validator@latest`.